### PR TITLE
Add browser bundles with dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,19 @@
         },
         "./liquid": {
             "import": "./dist/liquid/autocomplete.mjs",
+            "browser": "./dist/liquid/autocomplete.bundle.mjs",
             "require": "./dist/liquid/autocomplete.cjs",
             "types": "./dist/liquid/autocomplete.d.ts"
         },
         "./mustache": {
             "import": "./dist/mustache/autocomplete.mjs",
+            "browser": "./dist/mustache/autocomplete.bundle.mjs",
             "require": "./dist/mustache/autocomplete.cjs",
             "types": "./dist/mustache/autocomplete.d.ts"
         },
         "./handlebars": {
             "import": "./dist/handlebars/autocomplete.mjs",
+            "browser": "./dist/handlebars/autocomplete.bundle.mjs",
             "require": "./dist/handlebars/autocomplete.cjs",
             "types": "./dist/handlebars/autocomplete.d.ts"
         },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -70,7 +70,10 @@ function createBuildConfig(input, outputTemplate, ...plugins) {
 function createBundleConfig(input, outputTemplate) {
   return {
     plugins: [
-      resolve(), 
+      resolve({ 
+        browser: true,
+        mainFields: ['browser', 'module', 'main']
+      }), 
       commonjs(),
       esbuild({
         minify: true

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -70,10 +70,14 @@ function createBuildConfig(input, outputTemplate, ...plugins) {
 function createBundleConfig(input, outputTemplate) {
   return {
     plugins: [
-      resolve({ 
-        browser: true,
-        mainFields: ['browser', 'module', 'main']
-      }), 
+      resolve(),
+      alias({
+        entries: [
+          { find: 'handlebars', replacement: 'handlebars/lib/handlebars.js' },
+          { find: 'mustache', replacement: 'mustache/mustache.mjs' },
+          { find: 'liquid', replacement: 'liquid/dist/liquid.browser.mjs' }
+        ]
+      }),
       commonjs(),
       esbuild({
         minify: true

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -70,7 +70,10 @@ function createBuildConfig(input, outputTemplate, ...plugins) {
 function createBundleConfig(input, outputTemplate) {
   return {
     plugins: [
-      resolve(),
+      resolve({ 
+        browser: true,
+        mainFields: ['browser', 'module', 'main']
+      }),
       alias({
         entries: [
           { find: 'handlebars', replacement: 'handlebars/lib/handlebars.js' },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,12 +21,17 @@ const external = [
 ]
 
 export default [
+  // library artifacts
   ...createConfigs('src/index.ts', 'dist/autocomplete.[ext]'),
   ...createConfigs('src/react.ts', 'dist/preact/autocomplete.[ext]', preactAlias),
   ...createConfigs('src/react.ts', 'dist/react/autocomplete.[ext]'),
   ...createConfigs('src/liquid.ts', 'dist/liquid/autocomplete.[ext]'),
   ...createConfigs('src/handlebars.ts', 'dist/handlebars/autocomplete.[ext]'),
   ...createConfigs('src/mustache.ts', 'dist/mustache/autocomplete.[ext]'),
+  // bundle artifacts
+  createBundleConfig('src/liquid.ts', 'dist/liquid/autocomplete.[ext]'),
+  createBundleConfig('src/handlebars.ts', 'dist/handlebars/autocomplete.[ext]'),
+  createBundleConfig('src/mustache.ts', 'dist/mustache/autocomplete.[ext]')
 ]
 
 function createConfigs(input, outputTemplate, ...plugins) {
@@ -59,6 +64,29 @@ function createBuildConfig(input, outputTemplate, ...plugins) {
       format,
       sourcemap: true,
     }))
+  }
+}
+
+function createBundleConfig(input, outputTemplate) {
+  return {
+    plugins: [
+      resolve(), 
+      commonjs(),
+      esbuild({
+        minify: true
+      }),
+      string({
+        include: '**/*.{handlebars,mustache,liquid}',
+      })
+    ],
+    input,
+    output: [
+      {
+        file: outputTemplate.replace("[ext]", "bundle.mjs"),
+        format: "es",
+        sourcemap: true,
+      }
+    ]
   }
 }
 

--- a/spec/library.spec.js
+++ b/spec/library.spec.js
@@ -1,0 +1,41 @@
+import { describe } from "vitest"
+import "@testing-library/jest-dom"
+import {
+  autocompleteSuite
+} from "./suites/autocomplete"
+import {
+  fromHandlebarsTemplate,
+  defaultHandlebarsTemplate as handlebarsTemplate,
+} from "../dist/handlebars/autocomplete.bundle.mjs"
+import {
+  fromMustacheTemplate,
+  defaultMustacheTemplate as mustacheTemplate,
+} from "../dist/mustache/autocomplete.bundle.mjs"
+import {
+  fromLiquidTemplate,
+  defaultLiquidTemplate as liquidTemplate,
+} from "../dist/liquid/autocomplete.bundle.mjs"
+
+describe("library bundles", () => {
+  describe("fromHandlebarsTemplate", () => {
+    autocompleteSuite({
+      render: fromHandlebarsTemplate(handlebarsTemplate),
+      basic: true
+    })
+  })
+  
+  describe("fromMustacheTemplate", () => {
+    autocompleteSuite({
+      render: fromMustacheTemplate(mustacheTemplate),
+      basic: true
+    })
+  })
+  
+  describe("fromLiquidTemplate", () => {
+    autocompleteSuite({
+      render: fromLiquidTemplate(liquidTemplate),
+      basic: true
+    })
+  })
+})
+

--- a/spec/suites/autocomplete.ts
+++ b/spec/suites/autocomplete.ts
@@ -82,9 +82,10 @@ export function hooks() {
 
 interface SuiteProps {
   render: AutocompleteConfig<DefaultState>["render"]
+  basic?: boolean
 }
 
-export function autocompleteSuite({ render }: SuiteProps) {
+export function autocompleteSuite({ render, basic }: SuiteProps) {
   hooks()
 
   it("renders autocomplete", async () => {
@@ -118,6 +119,10 @@ export function autocompleteSuite({ render }: SuiteProps) {
       }
     )
   })
+
+  if (basic) {
+    return
+  }
 
   describe("history", () => {
     it("should see results after typing", async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     port: 8080
   },
   test: {
-    include: ["./spec/**/*.spec.{ts,tsx}"],
+    include: ["./spec/**/*.spec.{js,ts,tsx}"],
     environment: "jsdom",
     globals: true,
     environmentOptions: {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

To make usage of Nosto Autocomplete directly in the browser easier browser bundles (with included dedendencies) are provided for the following variants
* liquid
* handlebars
* mustache

```
timo.westkamper@OnePlusNord nosto-autocomplete % ls -lh dist/mustache 
total 640
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.bundle.mjs
-rw-r--r--  1 timo.westkamper  staff    97K Apr  7 20:19 autocomplete.bundle.mjs.map
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.cjs
-rw-r--r--  1 timo.westkamper  staff    65K Apr  7 20:19 autocomplete.cjs.map
-rw-r--r--  1 timo.westkamper  staff    11K Apr  7 20:19 autocomplete.d.ts
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.mjs
-rw-r--r--  1 timo.westkamper  staff    65K Apr  7 20:19 autocomplete.mjs.map
timo.westkamper@OnePlusNord nosto-autocomplete % ls -lh dist/handlebars 
total 1192
-rw-r--r--  1 timo.westkamper  staff    84K Apr  7 20:19 autocomplete.bundle.mjs
-rw-r--r--  1 timo.westkamper  staff   308K Apr  7 20:19 autocomplete.bundle.mjs.map
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.cjs
-rw-r--r--  1 timo.westkamper  staff    65K Apr  7 20:19 autocomplete.cjs.map
-rw-r--r--  1 timo.westkamper  staff    10K Apr  7 20:19 autocomplete.d.ts
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.mjs
-rw-r--r--  1 timo.westkamper  staff    65K Apr  7 20:19 autocomplete.mjs.map
timo.westkamper@OnePlusNord nosto-autocomplete % ls -lh dist/liquid    
total 1280
-rw-r--r--  1 timo.westkamper  staff    89K Apr  7 20:19 autocomplete.bundle.mjs
-rw-r--r--  1 timo.westkamper  staff   349K Apr  7 20:19 autocomplete.bundle.mjs.map
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.cjs
-rw-r--r--  1 timo.westkamper  staff    65K Apr  7 20:19 autocomplete.cjs.map
-rw-r--r--  1 timo.westkamper  staff    11K Apr  7 20:19 autocomplete.d.ts
-rw-r--r--  1 timo.westkamper  staff    22K Apr  7 20:19 autocomplete.mjs
-rw-r--r--  1 timo.westkamper  staff    65K Apr  7 20:19 autocomplete.mjs.map
```

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
