### PR TITLE
fix: Support custom templates through script block

### DIFF
--- a/spec/suites/webcomponents.ts
+++ b/spec/suites/webcomponents.ts
@@ -170,23 +170,32 @@ export function webComponentSuite({ template, component }: SuiteProps) {
     })
   })
 
-  it("should get external template", async () => {
+  it("should get custom template", async () => {
     const user = userEvent.setup()
 
+    document.body.innerHTML = `
+      <nosto-autocomplete>
+        <form>
+          <input type="text" id="search-wc" placeholder="search" data-testid="input" />
+          <button type="submit" id="search-button">Search</button>
+          <div id="search-results-wc" class="ns-autocomplete" data-testid="dropdown"></div>
+        </form>
+        <script autocomplete-config>${JSON.stringify(config)}</script>
+        <script type="text/template" autocomplete-template>
+          <div data-testid="custom-template">
+            Custom Template Content
+          </div>
+        </script>
+      </nosto-autocomplete>
+      `
+
     const element = document.querySelector<CustomElement>("nosto-autocomplete")!
-
-    const templateEl = document.createElement("script")
-    templateEl.setAttribute("type", "text/template")
-    templateEl.setAttribute("autocomplete-template", "")
-
-    templateEl.textContent = `<div data-testid="custom-template">External Template Content</div>`
-    document.body.append(templateEl)
 
     await waitFor(() => element.connectedCallback())
     await user.type(screen.getByTestId("input"), "black")
     await waitFor(() =>
       expect(screen.getByTestId("custom-template")).toHaveTextContent(
-        "External Template Content"
+        "Custom Template Content"
       )
     )
   })

--- a/spec/suites/webcomponents.ts
+++ b/spec/suites/webcomponents.ts
@@ -49,7 +49,6 @@ function webComponentSuiteHooks(template: string) {
             <div id="search-results-wc" class="ns-autocomplete" data-testid="dropdown"></div>
           </form>
           <script autocomplete-config>${JSON.stringify(config)}</script>
-          <template>${template}</template>
         </nosto-autocomplete>
       `
     searchSpy = vi.fn(async () => searchResponse as unknown as SearchResult)
@@ -79,14 +78,16 @@ export function webComponentSuite({ template, component }: SuiteProps) {
   it("should render autocomplete with the correct config and template", async () => {
     const element = document.querySelector<CustomElement>("nosto-autocomplete")!
     const user = userEvent.setup()
-    const scriptElement = element?.querySelector("script[autocomplete-config]")
-    scriptElement!.textContent = JSON.stringify(config)
-    const templateEl = document.querySelector("template")!
-    templateEl.innerText = `
+    const templateEl = document.createElement("script")
+    templateEl.setAttribute("type", "text/template")
+    templateEl.setAttribute("autocomplete-template", "")
+    templateEl.textContent = `
     <div data-testid="custom-template"
      ${template}
     </div>
     `
+    element.append(templateEl)
+
     await waitFor(() => element.connectedCallback())
 
     expect(screen.getByTestId("input")).toHaveAttribute("autocomplete", "off")
@@ -133,9 +134,7 @@ export function webComponentSuite({ template, component }: SuiteProps) {
   it("should use the default template if custom template is not supplied", async () => {
     const user = userEvent.setup()
     const element = document.querySelector<CustomElement>("nosto-autocomplete")!
-    element.querySelector("template")?.remove()
-    const scriptElement = element.querySelector("script[autocomplete-config]")
-    scriptElement!.textContent = JSON.stringify(config)
+    element.querySelector("script[autocomplete-template]")?.remove()
     await waitFor(() => element.connectedCallback())
 
     await waitFor(
@@ -171,25 +170,17 @@ export function webComponentSuite({ template, component }: SuiteProps) {
     })
   })
 
-  it("should use the template with specified template id", async () => {
+  it("should get external template", async () => {
     const user = userEvent.setup()
-
-    const templateEl = document.createElement("template")
-    templateEl.setAttribute("id", "external-template")
-    templateEl.innerText = `
-      <div data-testid="custom-template">
-        External Template Content
-      </div>
-    `
-    document.body.append(templateEl)
 
     const element = document.querySelector<CustomElement>("nosto-autocomplete")!
 
-    element.setAttribute("template", "external-template")
-    element.querySelector("template")?.remove()
+    const templateEl = document.createElement("script")
+    templateEl.setAttribute("type", "text/template")
+    templateEl.setAttribute("autocomplete-template", "")
 
-    const scriptElement = element.querySelector("script[autocomplete-config]")
-    scriptElement!.textContent = JSON.stringify(config)
+    templateEl.textContent = `<div data-testid="custom-template">External Template Content</div>`
+    document.body.append(templateEl)
 
     await waitFor(() => element.connectedCallback())
     await user.type(screen.getByTestId("input"), "black")

--- a/src/handlebars/NostoAutocomplete.ts
+++ b/src/handlebars/NostoAutocomplete.ts
@@ -35,14 +35,14 @@ import {
  *       }
  *     }
  *   </script>
- *   <template>
+ *   <script type="text/x-handlebars-template" autocomplete-template>
  *     <h1>{{query}}</h1>
  *     <ul>
  *       {{#each products}}
  *         <li>{{name}}</li>
  *       {{/each}}
  *     </ul>
- *   </template>
+ *   </script>
  * </nosto-autocomplete>
  * ```
  */

--- a/src/lib/wcAutocompleteHandler.ts
+++ b/src/lib/wcAutocompleteHandler.ts
@@ -14,7 +14,7 @@ export async function initAutocomplete(
   element: HTMLElement,
   { handler, defaultTemplate }: TemplateProps,
 ): Promise<AutocompleteInstance> {
-  const templateElement = document.querySelector<HTMLScriptElement>("script[autocomplete-template]")?.textContent
+  const templateContent = element.querySelector<HTMLScriptElement>("script[autocomplete-template]")?.textContent
 
   if (!Object.keys(getConfigFromScript(element)).length) {
     throw new Error("NostoAutocomplete: Missing required config.")
@@ -23,7 +23,7 @@ export async function initAutocomplete(
   const config = getConfigFromScript(element)
   return await autocomplete({
     ...config,
-    render: handler(templateElement ?? defaultTemplate),
+    render: handler(templateContent ?? defaultTemplate),
   })
 }
 

--- a/src/lib/wcAutocompleteHandler.ts
+++ b/src/lib/wcAutocompleteHandler.ts
@@ -14,10 +14,7 @@ export async function initAutocomplete(
   element: HTMLElement,
   { handler, defaultTemplate }: TemplateProps,
 ): Promise<AutocompleteInstance> {
-  const templateId = element.getAttribute("template")
-  const templateElement = templateId
-    ? document.getElementById(templateId)
-    : element.querySelector<HTMLTemplateElement>("template")
+  const templateElement = document.querySelector<HTMLScriptElement>("script[autocomplete-template]")?.textContent
 
   if (!Object.keys(getConfigFromScript(element)).length) {
     throw new Error("NostoAutocomplete: Missing required config.")
@@ -26,7 +23,7 @@ export async function initAutocomplete(
   const config = getConfigFromScript(element)
   return await autocomplete({
     ...config,
-    render: handler(templateElement?.innerText ?? defaultTemplate),
+    render: handler(templateElement ?? defaultTemplate),
   })
 }
 

--- a/src/liquid/NostoAutocomplete.ts
+++ b/src/liquid/NostoAutocomplete.ts
@@ -32,14 +32,14 @@ import { fromLiquidTemplate, defaultLiquidTemplate } from "./fromLiquidTemplate"
  *       }
  *     }
  *   </script>
- *   <template>
+ *   <script type="text/x-liquid" autocomplete-template>
  *     <h1>{{ query }}</h1>
  *     <ul>
  *       {% for product in products %}
  *         <li>{{ product.name }}</li>
  *       {% endfor %}
  *     </ul>
- *   </template>
+ *   </script>
  * </nosto-autocomplete>
  * ```
  */

--- a/src/mustache/NostoAutocomplete.ts
+++ b/src/mustache/NostoAutocomplete.ts
@@ -35,14 +35,14 @@ import {
  *       }
  *     }
  *   </script>
- *   <template>
+ *   <script type="text/x-mustache-template" autocomplete-template>
  *     <h1>{{query}}</h1>
  *     <ul>
  *       {{#products}}
  *         <li>{{name}}</li>
  *       {{/products}}
  *     </ul>
- *   </template>
+ *   </script>
  * </nosto-autocomplete>
  * ```
  */


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

Based on the discovery made by @timowestnosto , we've decided to move the custom template support to inside a script block instead of template block mainly due to the reason that <template> block contents are parsed as HTML which is not ideal with templating language cases like Handlebars, Mustache and Liquid.

* Converts the usage of template to script
* Update test

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

Parent:
https://nostosolutions.atlassian.net/browse/CFE-995

Task:
https://nostosolutions.atlassian.net/browse/CFE-999

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
