### PR TITLE
fix: bypass submit handler from autocomplete web component

### DIFF
--- a/spec/suites/webcomponents.ts
+++ b/spec/suites/webcomponents.ts
@@ -2,8 +2,6 @@ import { beforeEach, Mock, vi } from "vitest"
 import userEvent from "@testing-library/user-event"
 import { screen, waitFor } from "@testing-library/dom"
 import "@testing-library/jest-dom"
-import { DefaultState } from "../../src"
-import { getDefaultConfig } from "../../src/lib/config"
 import { mockNostojs } from "@nosto/nosto-js/testing"
 import searchResponse from "../responses/search.json"
 import type { API, SearchResult } from "@nosto/nosto-js/client"
@@ -32,7 +30,7 @@ const config = {
       fields: ["keyword", "_highlight.keyword"],
     },
   },
-  submit: getDefaultConfig<DefaultState>().submit,
+  submit: vi.fn(),
 }
 
 function webComponentSuiteHooks(template: string) {

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -22,6 +22,8 @@ export async function initAutocomplete(
   return autocomplete({
     ...config,
     render: handler(templateContent ?? defaultTemplate),
+    // Omit submit handler from web component for native form submission behavior
+    submit: () => {}
   })
 }
 


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

Currently, the web component does not support native form submit event since the defaultConfig has onSubmit as default. Bypassing this, the native form submission can be now achieved. However, it should be noted that this leaves the related search call implementation to developer.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

https://nostosolutions.atlassian.net/browse/CFE-1007

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
