### PR TITLE
feat: migrate to using trusted publishing from NPMJS token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           node-version: 24
           cache: "npm"
-          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm ci
@@ -61,6 +60,7 @@ jobs:
         with:
           node-version: 24
           cache: "npm"
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request updates the GitHub Actions workflow for releases, focusing on improving permissions, updating dependencies, and cleaning up environment variables.

Workflow improvements:

* Added explicit permissions for `contents: read` and `id-token: write` to the workflow, enhancing security and enabling OIDC-based authentication.

Dependency updates:

* Updated the `semantic_version` input for the `semantic-release-action` to version `25.0.2`, ensuring the workflow uses the latest release features and fixes.

Environment cleanup:

* Removed the `NPM_TOKEN` environment variable from the release job, likely because it is no longer needed or handled differently.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
