### PR TITLE
[codex] Remove npm audit from workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,4 +24,4 @@ jobs:
           cache: "npm"
 
       - name: Install JavaScript dependencies
-        run: npm ci
+        run: npm ci --no-audit

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,10 +37,7 @@ jobs:
           node-version: 24
           cache: 'npm'
 
-      - run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
+      - run: npm ci --no-audit
 
       - run: npm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
+        run: npm ci --no-audit
 
       - name: Build project
         run: npm run build
@@ -66,10 +63,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
+        run: npm ci --no-audit
 
       - name: Download target directories
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

- Remove explicit npm audit --audit-level=high steps from the docs and release workflows.
- Add --no-audit to workflow npm ci installs so dependency installation does not trigger npm audit requests.

## Impact

GitHub workflows continue installing dependencies, building, testing, deploying docs, and releasing without running npm audit as part of CI.

## Validation

- rg -n "npm audit|audit-ci|npm_config_audit|--audit|Audit dependencies" .github/workflows returns no matches.
- git diff --check passes.